### PR TITLE
Add new coupon list page

### DIFF
--- a/aboon.xcodeproj/project.pbxproj
+++ b/aboon.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		D084FE50CD8DB5999660C5CA /* Pods_aboonTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FABED289BBF482EDDFCBF9B9 /* Pods_aboonTests.framework */; };
 		FE1F69DD20FB64F800CBF60A /* MyCouponListCollectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1F69DC20FB64F800CBF60A /* MyCouponListCollectionModel.swift */; };
 		FE1F69DF20FB657C00CBF60A /* TestCoupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1F69DE20FB657B00CBF60A /* TestCoupon.swift */; };
+		FE9A3AAE210D59A600603F4C /* NewCouponListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AAD210D59A600603F4C /* NewCouponListViewController.swift */; };
+		FE9A3AB0210D5A1800603F4C /* NewCouponlistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AAF210D5A1800603F4C /* NewCouponlistView.swift */; };
+		FE9A3AB2210D5A9300603F4C /* NewCouponListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AB1210D5A9300603F4C /* NewCouponListCollectionView.swift */; };
+		FE9A3AB4210D5AE600603F4C /* NewCouponListCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AB3210D5AE600603F4C /* NewCouponListCollectionCell.swift */; };
 		FEA3DA362102F9D1007F69B6 /* TestUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA3DA352102F9D1007F69B6 /* TestUser.swift */; };
 		FEA3DA38210302DD007F69B6 /* MyMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA3DA37210302DD007F69B6 /* MyMenuModel.swift */; };
 		FEA3DA3A210305D3007F69B6 /* MyMenuTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA3DA39210305D3007F69B6 /* MyMenuTableView.swift */; };
@@ -117,6 +121,10 @@
 		FABED289BBF482EDDFCBF9B9 /* Pods_aboonTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_aboonTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE1F69DC20FB64F800CBF60A /* MyCouponListCollectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCouponListCollectionModel.swift; sourceTree = "<group>"; };
 		FE1F69DE20FB657B00CBF60A /* TestCoupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCoupon.swift; sourceTree = "<group>"; };
+		FE9A3AAD210D59A600603F4C /* NewCouponListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponListViewController.swift; sourceTree = "<group>"; };
+		FE9A3AAF210D5A1800603F4C /* NewCouponlistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponlistView.swift; sourceTree = "<group>"; };
+		FE9A3AB1210D5A9300603F4C /* NewCouponListCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponListCollectionView.swift; sourceTree = "<group>"; };
+		FE9A3AB3210D5AE600603F4C /* NewCouponListCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponListCollectionCell.swift; sourceTree = "<group>"; };
 		FEA3DA352102F9D1007F69B6 /* TestUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUser.swift; sourceTree = "<group>"; };
 		FEA3DA37210302DD007F69B6 /* MyMenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMenuModel.swift; sourceTree = "<group>"; };
 		FEA3DA39210305D3007F69B6 /* MyMenuTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyMenuTableView.swift; path = aboon/Classes/MyPage/View/MyMenuTableView.swift; sourceTree = SOURCE_ROOT; };
@@ -594,6 +602,9 @@
 		FE9A3AAA210D594F00603F4C /* View */ = {
 			isa = PBXGroup;
 			children = (
+				FE9A3AAF210D5A1800603F4C /* NewCouponlistView.swift */,
+				FE9A3AB1210D5A9300603F4C /* NewCouponListCollectionView.swift */,
+				FE9A3AB3210D5AE600603F4C /* NewCouponListCollectionCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -608,6 +619,7 @@
 		FE9A3AAC210D595A00603F4C /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				FE9A3AAD210D59A600603F4C /* NewCouponListViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -891,9 +903,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FE9A3AB4210D5AE600603F4C /* NewCouponListCollectionCell.swift in Sources */,
 				2C1541BF20E208C8001941ED /* NavigationItem.swift in Sources */,
 				FEA3DA3C21030832007F69B6 /* MyMenuView.swift in Sources */,
 				2CD0154E20E1007E008F16F6 /* MyMenuViewController.swift in Sources */,
+				FE9A3AB2210D5A9300603F4C /* NewCouponListCollectionView.swift in Sources */,
 				2CD6216320DF695A00C81DF7 /* EditProfileViewController.swift in Sources */,
 				2CD6215220DF52A900C81DF7 /* CouponDetailViewController.swift in Sources */,
 				2CD6215020DF529C00C81DF7 /* CouponListViewController.swift in Sources */,
@@ -902,6 +916,7 @@
 				2CD6214820DF50D300C81DF7 /* MyCouponViewController.swift in Sources */,
 				869A986020E731FB00BF924F /* CouponListCollectionModel.swift in Sources */,
 				FEA3DA362102F9D1007F69B6 /* TestUser.swift in Sources */,
+				FE9A3AAE210D59A600603F4C /* NewCouponListViewController.swift in Sources */,
 				2C0EDC4220DE111200F0F8E8 /* CategoryViewController.swift in Sources */,
 				49ADCD8E20E2955400EB1181 /* CategoryView.swift in Sources */,
 				2C1541C520E364BF001941ED /* CategoryCollectionView.swift in Sources */,
@@ -914,6 +929,7 @@
 				FEA3DA3E21030DB2007F69B6 /* MyMenuTableViewCell.swift in Sources */,
 				2C04E51320E0AFB500AECC8E /* NavigationController.swift in Sources */,
 				75193E4B20DBB8FA00EF417E /* Debug.swift in Sources */,
+				FE9A3AB0210D5A1800603F4C /* NewCouponlistView.swift in Sources */,
 				7507BE3F20E145A900749F59 /* R.generated.swift in Sources */,
 				2C1541C320E22DAD001941ED /* CategoryCollectionModel.swift in Sources */,
 				2CD6216920DF7EE700C81DF7 /* UIColorHex.swift in Sources */,

--- a/aboon.xcodeproj/project.pbxproj
+++ b/aboon.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		75FC808C20F22A92007ED73B /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				FE9A3AA9210D593E00603F4C /* new_Coupon */,
 				2CD6215320DF533B00C81DF7 /* MyPage */,
 				2C0EDC4620DE1E0700F0F8E8 /* MyCoupon */,
 				2C0EDC4520DE1DFD00F0F8E8 /* Category */,
@@ -552,7 +553,6 @@
 		79F482AD21030929003B28F5 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				2C1541C220E22DAD001941ED /* CategoryCollectionModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -560,7 +560,6 @@
 		79F482AE21030989003B28F5 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				869A985F20E731FB00BF924F /* CouponListCollectionModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -580,6 +579,37 @@
 				8B1F13BE461DBB15F9848EB4 /* Pods_aboonUITests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FE9A3AA9210D593E00603F4C /* new_Coupon */ = {
+			isa = PBXGroup;
+			children = (
+				FE9A3AAC210D595A00603F4C /* Controller */,
+				FE9A3AAB210D595500603F4C /* Model */,
+				FE9A3AAA210D594F00603F4C /* View */,
+			);
+			path = new_Coupon;
+			sourceTree = "<group>";
+		};
+		FE9A3AAA210D594F00603F4C /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		FE9A3AAB210D595500603F4C /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		FE9A3AAC210D595A00603F4C /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Controller;
 			sourceTree = "<group>";
 		};
 		FEA3DA342102F9C0007F69B6 /* Model */ = {

--- a/aboon.xcodeproj/project.pbxproj
+++ b/aboon.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		FE9A3AB0210D5A1800603F4C /* NewCouponlistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AAF210D5A1800603F4C /* NewCouponlistView.swift */; };
 		FE9A3AB2210D5A9300603F4C /* NewCouponListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AB1210D5A9300603F4C /* NewCouponListCollectionView.swift */; };
 		FE9A3AB4210D5AE600603F4C /* NewCouponListCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AB3210D5AE600603F4C /* NewCouponListCollectionCell.swift */; };
+		FE9A3AB6210D65EA00603F4C /* NewCouponListCollectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A3AB5210D65EA00603F4C /* NewCouponListCollectionModel.swift */; };
 		FEA3DA362102F9D1007F69B6 /* TestUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA3DA352102F9D1007F69B6 /* TestUser.swift */; };
 		FEA3DA38210302DD007F69B6 /* MyMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA3DA37210302DD007F69B6 /* MyMenuModel.swift */; };
 		FEA3DA3A210305D3007F69B6 /* MyMenuTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA3DA39210305D3007F69B6 /* MyMenuTableView.swift */; };
@@ -125,6 +126,7 @@
 		FE9A3AAF210D5A1800603F4C /* NewCouponlistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponlistView.swift; sourceTree = "<group>"; };
 		FE9A3AB1210D5A9300603F4C /* NewCouponListCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponListCollectionView.swift; sourceTree = "<group>"; };
 		FE9A3AB3210D5AE600603F4C /* NewCouponListCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponListCollectionCell.swift; sourceTree = "<group>"; };
+		FE9A3AB5210D65EA00603F4C /* NewCouponListCollectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCouponListCollectionModel.swift; sourceTree = "<group>"; };
 		FEA3DA352102F9D1007F69B6 /* TestUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUser.swift; sourceTree = "<group>"; };
 		FEA3DA37210302DD007F69B6 /* MyMenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMenuModel.swift; sourceTree = "<group>"; };
 		FEA3DA39210305D3007F69B6 /* MyMenuTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyMenuTableView.swift; path = aboon/Classes/MyPage/View/MyMenuTableView.swift; sourceTree = SOURCE_ROOT; };
@@ -612,6 +614,7 @@
 		FE9A3AAB210D595500603F4C /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				FE9A3AB5210D65EA00603F4C /* NewCouponListCollectionModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -911,6 +914,7 @@
 				2CD6216320DF695A00C81DF7 /* EditProfileViewController.swift in Sources */,
 				2CD6215220DF52A900C81DF7 /* CouponDetailViewController.swift in Sources */,
 				2CD6215020DF529C00C81DF7 /* CouponListViewController.swift in Sources */,
+				FE9A3AB6210D65EA00603F4C /* NewCouponListCollectionModel.swift in Sources */,
 				2CA3DA6720E3C23D00D3A9CA /* CouponListCollectionView.swift in Sources */,
 				FEA3DABF21045B9E007F69B6 /* SideMenuNavigationBar.swift in Sources */,
 				2CD6214820DF50D300C81DF7 /* MyCouponViewController.swift in Sources */,

--- a/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
+++ b/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
@@ -46,5 +46,7 @@ class NewCouponListViewController: UIViewController {
             collectionView.deselectItem(at: indexPath, animated: true)
             dLog("selected:\(indexPath.row)")
             
+            let couponDetailViewController = CouponDetailViewController(withTitle: model.titles[indexPath.row])
+            self.navigationController?.pushViewController(couponDetailViewController, animated: true)
     }
 }

--- a/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
+++ b/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class NewCouponListViewController: UIViewController {
-    let view: NewCouponListView?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
+++ b/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  NewCouponListViewController.swift
 //  aboon
 //
 //  Created by EXIST on 2018/07/29.
@@ -10,8 +10,41 @@ import UIKit
 
 class NewCouponListViewController: UIViewController {
     
+    let model = NewCouponListCollectionModel()
+    
+    //navname
+    private var titleName = String()
+    
+    init(withTitle: String) {
+        self.titleName = withTitle
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    override func loadView() {
+        self.view = NewCouponListView()
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .white
+        
+        self.navigationItem.title = titleName
+        self.view.backgroundColor = UIColor(hex: "F5F5F5", alpha: 1.0)
+        
+        let newCouponlistCollectionView = (self.view as! NewCouponListView).createCollectionView()
+        
+        newCouponlistCollectionView.register(NewCouponListCollectionViewCell.self, forCellWithReuseIdentifier: "NewCouponListCollectionViewCell")
+        
+        newCouponlistCollectionView.delegate = self
+        newCouponlistCollectionView.dataSource = model as! UICollectionViewDataSource
+        (self.view as! NewCouponListView).appendCollectionView(newCouponlistCollectionView)
+    }
+}
+    extension NewCouponListViewController: UICollectionViewDelegate{
+        func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+            collectionView.deselectItem(at: indexPath, animated: true)
+            dLog("selected:\(indexPath.row)")
+            
     }
 }

--- a/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
+++ b/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
@@ -1,0 +1,15 @@
+//
+//  File.swift
+//  aboon
+//
+//  Created by EXIST on 2018/07/29.
+//  Copyright © 2018年 aboon. All rights reserved.
+//
+
+import UIKit
+
+class NewCouponListViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
+++ b/aboon/Classes/new_Coupon/Controller/NewCouponListViewController.swift
@@ -9,7 +9,10 @@
 import UIKit
 
 class NewCouponListViewController: UIViewController {
+    let view: NewCouponListView?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.view.backgroundColor = .white
     }
 }

--- a/aboon/Classes/new_Coupon/Model/NewCouponListCollectionModel.swift
+++ b/aboon/Classes/new_Coupon/Model/NewCouponListCollectionModel.swift
@@ -1,0 +1,15 @@
+//
+//  NewCouponListModel.swift
+//  aboon
+//
+//  Created by EXIST on 2018/07/29.
+//  Copyright © 2018年 aboon. All rights reserved.
+//
+import UIKit
+class NewCouponListCollectionModel: NSObject {
+    //test data
+    var titles = ["coupon1", "coupon2", "coupon3", "coupon4", "coupon5", "coupon6"]
+    var details = ["detailA", "detailB", "detailC", "detailD", "detailE", "detailF"]
+    var couponImages = [R.image.airplaneSymbol7(), R.image.basketball7(), R.image.animalElement7(), R.image.albumSimple7(), R.image.bin7(), R.image.bookCoverTick7()]
+    var discounts =  ["10%OFF", "20%OFF", "30%OFF", "40%OFF", "50%OFF", "60%OFF"]
+}

--- a/aboon/Classes/new_Coupon/Model/NewCouponListCollectionModel.swift
+++ b/aboon/Classes/new_Coupon/Model/NewCouponListCollectionModel.swift
@@ -1,15 +1,31 @@
 //
-//  NewCouponListModel.swift
+//  NewCouponListCollectionModel.swift
 //  aboon
 //
 //  Created by EXIST on 2018/07/29.
 //  Copyright © 2018年 aboon. All rights reserved.
 //
 import UIKit
+
 class NewCouponListCollectionModel: NSObject {
     //test data
     var titles = ["coupon1", "coupon2", "coupon3", "coupon4", "coupon5", "coupon6"]
     var details = ["detailA", "detailB", "detailC", "detailD", "detailE", "detailF"]
-    var couponImages = [R.image.airplaneSymbol7(), R.image.basketball7(), R.image.animalElement7(), R.image.albumSimple7(), R.image.bin7(), R.image.bookCoverTick7()]
+    var couponImages = [R.image.number17(), R.image.number27(), R.image.number37(), R.image.number47(), R.image.number57(), R.image.number67()]
     var discounts =  ["10%OFF", "20%OFF", "30%OFF", "40%OFF", "50%OFF", "60%OFF"]
+}
+
+extension NewCouponListCollectionModel: UICollectionViewDataSource{
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return titles.count
+    }
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "NewCouponListCollectionViewCell", for: indexPath) as! NewCouponListCollectionViewCell
+        cell.couponNameLabel?.text = titles[indexPath.row]
+        cell.couponDetailLabel?.text = details[indexPath.row]
+        cell.couponImageView?.image = couponImages[indexPath.row]
+        cell.couponDiscountLabel?.text = discounts[indexPath.row]
+        return cell
+    }
+    
 }

--- a/aboon/Classes/new_Coupon/Model/NewCouponListCollectionModel.swift
+++ b/aboon/Classes/new_Coupon/Model/NewCouponListCollectionModel.swift
@@ -12,7 +12,7 @@ class NewCouponListCollectionModel: NSObject {
     var titles = ["coupon1", "coupon2", "coupon3", "coupon4", "coupon5", "coupon6"]
     var details = ["detailA", "detailB", "detailC", "detailD", "detailE", "detailF"]
     var couponImages = [R.image.number17(), R.image.number27(), R.image.number37(), R.image.number47(), R.image.number57(), R.image.number67()]
-    var discounts =  ["10%OFF", "20%OFF", "30%OFF", "40%OFF", "50%OFF", "60%OFF"]
+    var discounts =  ["10%\nOFF", "20%\nOFF", "30%\nOFF", "40%\nOFF", "50%\nOFF", "60%\nOFF"]
 }
 
 extension NewCouponListCollectionModel: UICollectionViewDataSource{

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -1,0 +1,21 @@
+//
+//  CouponListCell.swift
+//  aboon
+//
+//  Created by EXIST on 2018/07/29.
+//  Copyright © 2018年 aboon. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+class CouponListCollectionViewCell: UICollectionViewCell {
+    
+    var couponImageView: UIImageView?
+    var couponNameLabel: UILabel?
+    var couponDetailLabel: UILabel?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+}

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -47,7 +47,7 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
         addSubview(couponDetailLabel!)
         
         //initialazation of couponDiscountLabel
-        couponDiscountLabel = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width/3, height: frame.height/2))
+        couponDiscountLabel = UILabel(frame: CGRect(x: 0, y: 0, width:  frame.height/2, height: frame.height/2))
         //setting texts
         couponDiscountLabel?.font = UIFont(name:"Calibri", size: (couponDiscountLabel?.font.pointSize)!/2)
         couponDiscountLabel?.textColor = UIColor(hex: "FFFFFF", alpha: 1)
@@ -58,9 +58,9 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
         
         addSubview(couponDiscountLabel!)
         
-        roundEdge()
         //set constraints
         updateConstraintsIfNeeded()
+        roundEdge()
     }
     
     
@@ -71,22 +71,24 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
             make.height.equalTo(frame.height/2)
             make.top.left.equalToSuperview()
         })
-        couponDiscountLabel?.snp.makeConstraints({ (make) in make.width.height.equalTo((couponImageView?.snp.height)!)
-            make.top.equalTo((couponImageView?.snp.bottom)!)
-            make.left.equalToSuperview()
-            make.bottom.equalToSuperview()
+        couponDiscountLabel?.snp.makeConstraints({ (make) in make.width.height.equalTo(frame.height/2)
+            make.top.equalTo((couponImageView?.snp.bottom)!).offset(10)
+            make.left.equalToSuperview().offset(10)
+            make.bottom.equalToSuperview().offset(-10)
         })
         couponNameLabel?.snp.makeConstraints { (make) in
             make.height.equalTo(frame.height/4)
             make.width.equalTo(frame.width*2/3)
-            make.top.equalTo((couponImageView?.snp.bottom)!)
-            make.left.equalTo((couponDiscountLabel?.snp.right)!)
+            make.top.equalTo((couponImageView?.snp.bottom)!).offset(10)
+            make.left.equalTo((couponDiscountLabel?.snp.right)!).offset(10)
+            make.right.equalToSuperview().offset(-10)
         }
         couponDetailLabel?.snp.makeConstraints({ (make) in
             make.height.equalTo(frame.height/4)
             make.width.equalTo(frame.width*2/3)
             make.top.equalTo((couponNameLabel?.snp.bottom)!)
-            make.left.equalTo((couponDiscountLabel?.snp.right)!)
+            make.left.equalTo((couponDiscountLabel?.snp.right)!).offset(10)
+            make.bottom.right.equalToSuperview().offset(-10)
         })
     }
     

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -27,32 +27,36 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
         couponImageView?.contentMode = .scaleAspectFill
         couponImageView?.clipsToBounds = true
         addSubview(couponImageView!)
+
         //initialization of couponNameLabel
         couponNameLabel = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width*2/3, height: frame.height/2))
         //settings for texts
-        couponNameLabel?.font = UIFont(name: "Courier", size: (couponNameLabel?.font.pointSize)!)
+        couponNameLabel?.font = UIFont(name: "Roboto", size: 16)
         couponNameLabel?.textColor = .black
         //couponNameLabel?.font = UIFont.boldSystemFont(ofSize: (couponNameLabel?.font.pointSize)!)
         couponNameLabel?.text = "nil"
+        couponNameLabel?.adjustsFontSizeToFitWidth = true
         
         addSubview(couponNameLabel!)
         
         //initialazation of couponDetailLabel
         couponDetailLabel = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width*2/3, height: frame.height/2))
         //setting texts
-        couponDetailLabel?.font = UIFont(name:"Calibri", size: (couponNameLabel?.font.pointSize)!/2)
+        couponDetailLabel?.font = UIFont(name:"Roboto", size: 12)
         couponDetailLabel?.textColor = UIColor(hex: "000000", alpha: 0.5)
         couponDetailLabel?.text = "nil"
+        couponDetailLabel?.adjustsFontSizeToFitWidth = true
         
         addSubview(couponDetailLabel!)
         
         //initialazation of couponDiscountLabel
         couponDiscountLabel = UILabel(frame: CGRect(x: 0, y: 0, width:  frame.height/2, height: frame.height/2))
-        //setting texts
-        couponDiscountLabel?.font = UIFont(name:"Calibri", size: (couponDiscountLabel?.font.pointSize)!/2)
+        couponDiscountLabel?.font = UIFont(name:"Arial", size: 24)
         couponDiscountLabel?.textColor = UIColor(hex: "FFFFFF", alpha: 1)
         couponDiscountLabel?.text = "nil"
         couponDiscountLabel?.textAlignment = .center
+        couponDiscountLabel?.numberOfLines = 2
+        couponDiscountLabel?.adjustsFontSizeToFitWidth = true
         
         couponDiscountLabel?.backgroundColor = UIColor(hex: "FFC6B7", alpha: 1)
         
@@ -62,7 +66,6 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
         updateConstraintsIfNeeded()
         roundEdge()
     }
-    
     
     override func updateConstraints() {
         super.updateConstraints()

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -70,23 +70,18 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
         couponDiscountLabel?.snp.makeConstraints({ (make) in
             make.width.equalTo(frame.width/3)
             make.height.equalTo(frame.height/2)
-//            make.top.equalTo(frame.height/2)
             make.top.equalTo((couponImageView?.snp.bottom)!)
             make.left.equalTo(0)
         })
         couponNameLabel?.snp.makeConstraints { (make) in
             make.height.equalTo(frame.height/4)
             make.width.equalTo(frame.width*2/3)
-//            make.top.equalTo(frame.height/2)
-//            make.left.equalTo(frame.width/3)
             make.top.equalTo((couponImageView?.snp.bottom)!)
             make.left.equalTo((couponDiscountLabel?.snp.right)!)
         }
         couponDetailLabel?.snp.makeConstraints({ (make) in
             make.height.equalTo(frame.height/4)
             make.width.equalTo(frame.width*2/3)
-//            make.top.equalTo(frame.height*3/4)
-//            make.left.equalTo(frame.width/3)
             make.top.equalTo((couponNameLabel?.snp.bottom)!)
             make.left.equalTo((couponDiscountLabel?.snp.right)!)
         })

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -50,11 +50,15 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
         couponDiscountLabel = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width/3, height: frame.height/2))
         //setting texts
         couponDiscountLabel?.font = UIFont(name:"Calibri", size: (couponDiscountLabel?.font.pointSize)!/2)
-        couponDiscountLabel?.textColor = UIColor(hex: "000000", alpha: 0.5)
+        couponDiscountLabel?.textColor = UIColor(hex: "FFFFFF", alpha: 1)
         couponDiscountLabel?.text = "nil"
+        couponDiscountLabel?.textAlignment = .center
+        
+        couponDiscountLabel?.backgroundColor = UIColor(hex: "FFC6B7", alpha: 1)
         
         addSubview(couponDiscountLabel!)
         
+        roundEdge()
         //set constraints
         updateConstraintsIfNeeded()
     }
@@ -65,13 +69,12 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
         couponImageView?.snp.makeConstraints({ (make) in
             make.width.equalTo(frame.width)
             make.height.equalTo(frame.height/2)
-            make.top.left.equalTo(0)
+            make.top.left.equalToSuperview()
         })
-        couponDiscountLabel?.snp.makeConstraints({ (make) in
-            make.width.equalTo(frame.width/3)
-            make.height.equalTo(frame.height/2)
+        couponDiscountLabel?.snp.makeConstraints({ (make) in make.width.height.equalTo((couponImageView?.snp.height)!)
             make.top.equalTo((couponImageView?.snp.bottom)!)
-            make.left.equalTo(0)
+            make.left.equalToSuperview()
+            make.bottom.equalToSuperview()
         })
         couponNameLabel?.snp.makeConstraints { (make) in
             make.height.equalTo(frame.height/4)
@@ -86,6 +89,12 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
             make.left.equalTo((couponDiscountLabel?.snp.right)!)
         })
     }
+    
+    func  roundEdge() {
+        couponDiscountLabel?.layer.cornerRadius =  (couponDiscountLabel?.frame.height)! * 0.5
+        couponDiscountLabel?.clipsToBounds = true
+    }
+    
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SnapKit
 
-class CouponListCollectionViewCell: UICollectionViewCell {
+class NewCouponListCollectionViewCell: UICollectionViewCell {
     
     var couponImageView: UIImageView?
     var couponNameLabel: UILabel?
@@ -17,5 +17,9 @@ class CouponListCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -1,5 +1,5 @@
 //
-//  CouponListCell.swift
+//  NewCouponListCollectionViewCell.swift
 //  aboon
 //
 //  Created by EXIST on 2018/07/29.
@@ -14,9 +14,82 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
     var couponImageView: UIImageView?
     var couponNameLabel: UILabel?
     var couponDetailLabel: UILabel?
+    var couponDiscountLabel: UILabel?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
+        self.backgroundColor = .white
+        
+        //initialization of imageview
+        couponImageView = UIImageView(frame: CGRect(x: 0, y: 0, width: frame.width, height: frame.height/2))
+        //using scaleAspectFill considering images that are not cropped
+        couponImageView?.contentMode = .scaleAspectFill
+        couponImageView?.clipsToBounds = true
+        addSubview(couponImageView!)
+        //initialization of couponNameLabel
+        couponNameLabel = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width*2/3, height: frame.height/2))
+        //settings for texts
+        couponNameLabel?.font = UIFont(name: "Courier", size: (couponNameLabel?.font.pointSize)!)
+        couponNameLabel?.textColor = .black
+        //couponNameLabel?.font = UIFont.boldSystemFont(ofSize: (couponNameLabel?.font.pointSize)!)
+        couponNameLabel?.text = "nil"
+        
+        addSubview(couponNameLabel!)
+        
+        //initialazation of couponDetailLabel
+        couponDetailLabel = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width*2/3, height: frame.height/2))
+        //setting texts
+        couponDetailLabel?.font = UIFont(name:"Calibri", size: (couponNameLabel?.font.pointSize)!/2)
+        couponDetailLabel?.textColor = UIColor(hex: "000000", alpha: 0.5)
+        couponDetailLabel?.text = "nil"
+        
+        addSubview(couponDetailLabel!)
+        
+        //initialazation of couponDiscountLabel
+        couponDiscountLabel = UILabel(frame: CGRect(x: 0, y: 0, width: frame.width/3, height: frame.height/2))
+        //setting texts
+        couponDiscountLabel?.font = UIFont(name:"Calibri", size: (couponDiscountLabel?.font.pointSize)!/2)
+        couponDiscountLabel?.textColor = UIColor(hex: "000000", alpha: 0.5)
+        couponDiscountLabel?.text = "nil"
+        
+        addSubview(couponDiscountLabel!)
+        
+        //set constraints
+        updateConstraintsIfNeeded()
+    }
+    
+    
+    override func updateConstraints() {
+        super.updateConstraints()
+        couponImageView?.snp.makeConstraints({ (make) in
+            make.width.equalTo(frame.width)
+            make.height.equalTo(frame.height/2)
+            make.top.left.equalTo(0)
+        })
+        couponDiscountLabel?.snp.makeConstraints({ (make) in
+            make.width.equalTo(frame.width/3)
+            make.height.equalTo(frame.height/2)
+//            make.top.equalTo(frame.height/2)
+            make.top.equalTo((couponImageView?.snp.bottom)!)
+            make.left.equalTo(0)
+        })
+        couponNameLabel?.snp.makeConstraints { (make) in
+            make.height.equalTo(frame.height/4)
+            make.width.equalTo(frame.width*2/3)
+//            make.top.equalTo(frame.height/2)
+//            make.left.equalTo(frame.width/3)
+            make.top.equalTo((couponImageView?.snp.bottom)!)
+            make.left.equalTo((couponDiscountLabel?.snp.right)!)
+        }
+        couponDetailLabel?.snp.makeConstraints({ (make) in
+            make.height.equalTo(frame.height/4)
+            make.width.equalTo(frame.width*2/3)
+//            make.top.equalTo(frame.height*3/4)
+//            make.left.equalTo(frame.width/3)
+            make.top.equalTo((couponNameLabel?.snp.bottom)!)
+            make.left.equalTo((couponDiscountLabel?.snp.right)!)
+        })
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionCell.swift
@@ -71,7 +71,8 @@ class NewCouponListCollectionViewCell: UICollectionViewCell {
             make.height.equalTo(frame.height/2)
             make.top.left.equalToSuperview()
         })
-        couponDiscountLabel?.snp.makeConstraints({ (make) in make.width.height.equalTo(frame.height/2)
+        couponDiscountLabel?.snp.makeConstraints({ (make) in
+            make.width.height.equalTo(frame.height/2)
             make.top.equalTo((couponImageView?.snp.bottom)!).offset(10)
             make.left.equalToSuperview().offset(10)
             make.bottom.equalToSuperview().offset(-10)

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
@@ -25,7 +25,7 @@ class NewCouponListCollectionView: UICollectionView {
         let margin = CGFloat(frame.width/4)
         flowLayout.itemSize = CGSize(width: frame.width*7/8, height: frame.height/3)
         flowLayout.minimumLineSpacing = margin/8
-//        flowLayout.sectionInset = UIEdgeInsets(top: margin/8, left: margin, bottom: 0, right: margin)
+        flowLayout.sectionInset = UIEdgeInsets(top: margin/8, left: margin, bottom: 0, right: margin)
         self.collectionViewLayout = flowLayout
     }
     

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
@@ -17,5 +17,9 @@ class NewCouponListCollectionView: UICollectionView {
         //white → 0.96
         self.backgroundColor = UIColor(white: 0.96, alpha: 1)
     }
-
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
 }

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
@@ -23,7 +23,7 @@ class NewCouponListCollectionView: UICollectionView {
     func setLayout(){
         let flowLayout = UICollectionViewFlowLayout()
         let margin = CGFloat(frame.width/4)
-        flowLayout.itemSize = CGSize(width: frame.width*7/8, height: frame.height/3.5)
+        flowLayout.itemSize = CGSize(width: frame.width*7/8, height: frame.height/3)
         flowLayout.minimumLineSpacing = margin/8
 //        flowLayout.sectionInset = UIEdgeInsets(top: margin/8, left: margin, bottom: 0, right: margin)
         self.collectionViewLayout = flowLayout

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
@@ -1,0 +1,21 @@
+//
+//  NewCollectionViewCell.swift
+//  aboon
+//
+//  Created by EXIST on 2018/07/29.
+//  Copyright © 2018年 aboon. All rights reserved.
+//
+
+import Foundation
+
+import UIKit
+
+class NewCouponListCollectionView: UICollectionView {
+    
+    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
+        //white → 0.96
+        self.backgroundColor = UIColor(white: 0.96, alpha: 1)
+    }
+
+}

--- a/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponListCollectionView.swift
@@ -1,12 +1,10 @@
 //
-//  NewCollectionViewCell.swift
+//  NewCouponListCollectionView.swift
 //  aboon
 //
 //  Created by EXIST on 2018/07/29.
 //  Copyright © 2018年 aboon. All rights reserved.
 //
-
-import Foundation
 
 import UIKit
 
@@ -20,6 +18,15 @@ class NewCouponListCollectionView: UICollectionView {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setLayout(){
+        let flowLayout = UICollectionViewFlowLayout()
+        let margin = CGFloat(frame.width/4)
+        flowLayout.itemSize = CGSize(width: frame.width*7/8, height: frame.height/3.5)
+        flowLayout.minimumLineSpacing = margin/8
+//        flowLayout.sectionInset = UIEdgeInsets(top: margin/8, left: margin, bottom: 0, right: margin)
+        self.collectionViewLayout = flowLayout
     }
     
 }

--- a/aboon/Classes/new_Coupon/View/NewCouponlistView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponlistView.swift
@@ -1,5 +1,5 @@
 //
-//  new_CouponlistView.swift
+//  NewCouponListView.swift
 //  aboon
 //
 //  Created by EXIST on 2018/07/29.
@@ -10,13 +10,32 @@ import UIKit
 
 
 class NewCouponListView: UIView {
+
+    var newCouponListCollectionView: NewCouponListCollectionView!
+    
     override init(frame: CGRect) {
         super.init(frame:frame)
         self.frame = UIScreen.main.bounds
     }
     
+    public func appendCollectionView (_ collectionView: UICollectionView) {
+        self.addSubview(collectionView)
+        dLog("NewCouponListCollectionView Appended")
+    }
+    
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    public func createCollectionView () -> NewCouponListCollectionView {
+        newCouponListCollectionView = NewCouponListCollectionView(frame: frame, collectionViewLayout: UICollectionViewLayout())
+        return newCouponListCollectionView
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        newCouponListCollectionView.setLayout()
+    }
+
     
 }

--- a/aboon/Classes/new_Coupon/View/NewCouponlistView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponlistView.swift
@@ -1,0 +1,18 @@
+//
+//  new_CouponlistView.swift
+//  aboon
+//
+//  Created by EXIST on 2018/07/29.
+//  Copyright © 2018年 aboon. All rights reserved.
+//
+
+import UIKit
+
+
+class NewCouponListView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame:frame)
+        self.frame = UIScreen.main.bounds
+    }
+    
+}

--- a/aboon/Classes/new_Coupon/View/NewCouponlistView.swift
+++ b/aboon/Classes/new_Coupon/View/NewCouponlistView.swift
@@ -15,4 +15,8 @@ class NewCouponListView: UIView {
         self.frame = UIScreen.main.bounds
     }
     
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
 }


### PR DESCRIPTION
## 関連文書

 * 関連issue #46 

## 変更点概要
・実装したデザイン：https://xd.adobe.com/spec/e59aae39-d6b7-452b-4aad-7e3b700adec4-93ab/screen/1f420b5d-5ab3-4f08-8ead-4be9d97dd142/Select-Coupons/
・UIのみを実装

## 注意・伝達事項
・この「new_Couponlist」がクーポンリストになり、以前までの「Coupon」はショップリストになる予定
・ファイル名変更は@kazuneが行う予定(slackより)
・現在時点のdevelopブランチでカテゴリをDBから取得する機能が取得エラーで動かなかったので、直接NewCouponListViewControllerのVCから確認お願いします。確認用のコードです
```
//コードの場所: NavigationTabBar/Controller/TabBarController.swift
categoryNavigationController.viewControllers = [NewCouponListViewController(withTitle: "NewCouponListViewController")]
```
・7月で @kichie はこのプロジェクトから抜けます、不明な点があった場合slack飛ばしてください。

## このPull requestでやらないこと
・DBからの取得
・ショップページからクーポンページへのページ遷移

## チェックリスト
・なし


