### PR TITLE
myCouponsへ正しく書き込みがされない問題の修正

### DIFF
--- a/aboon/Classes/MyCoupon/Model/CouponRoomModel.swift
+++ b/aboon/Classes/MyCoupon/Model/CouponRoomModel.swift
@@ -188,7 +188,7 @@ class CouponRoomModel {
         if isAvailable {
             members.forEach { (member) in
                 let myCouponRef = usersRef.document(member.userId).collection("myCoupons").document(roomId)
-                myCouponRef.setData(["isAvailable" : true])
+                myCouponRef.setData(["isAvailable" : true], merge: true)
             }
         }
     }


### PR DESCRIPTION
## 関連文書

## 変更点概要
Firestoreのusers/{userId}/myCoupons/{id}へ書き込まれた内容がその後の書き込みで上書きされてしまうのをsetData()のmergeをtrueにすることで解決。

## 注意・伝達事項
 * データベースへの書き込み時はドキュメントを全て上書きしてしまわないか注意。
